### PR TITLE
trim the string before parsing

### DIFF
--- a/Logix/Network/HTTPRequest.cs
+++ b/Logix/Network/HTTPRequest.cs
@@ -154,7 +154,7 @@ namespace FrooxEngine.LogiX.Network
 		//  TOTP : 696969"
 		private Dictionary<string, string> FormatHeaders(string headers)
 		{
-			List<string> rawHeaderList = new List<string>(headers.Split('\n'));
+			List<string> rawHeaderList = new List<string>(headers.Trim().Split('\n'));
 			Dictionary<string, string> result = new Dictionary<string, string>();
 			rawHeaderList.ForEach((header) =>
 			{


### PR DESCRIPTION
it causes out of bound exception if you have a trailing newline