### PR TITLE
Updated

### DIFF
--- a/NEOSPlus/Materials/Effects/Hologram.cs
+++ b/NEOSPlus/Materials/Effects/Hologram.cs
@@ -8,35 +8,29 @@ public class Hologram : SingleShaderMaterialProvider
 {
 	protected override Uri ShaderURL => ShaderInjection.HologramV2;
 
-	// Main
 	public readonly AssetRef<ITexture2D> MainTexture;
 	public readonly Sync<color> MainColor;
 	public readonly AssetRef<ITexture2D> EmissionTexture;
 	public readonly Sync<color> EmissionColor;
-	// Repeating ramp
 	public readonly AssetRef<ITexture2D> RampTexture;
 	public readonly Sync<float> Scale;
 	public readonly Sync<float> ScrollSpeed;
-	// Fresnel
 	public readonly Sync<color> FresnelColor;
-	public readonly Sync<float> FresnelExponent;
-
+    [Range(0f, 5f, "0.00")]
+    public readonly Sync<float> FresnelExponent;
 	[DefaultValue(-1)]
 	public readonly Sync<int> RenderQueue;
 	private static PropertyState _propertyInitializationState;
 
-	// Main
 	private static MaterialProperty _MainTexture = new("_MainTexture");
 	private static MaterialProperty _MainColor = new("_MainColor");
 	private static MaterialProperty _EmissionTexture = new("_EmissionTexture");
 	private static MaterialProperty _EmissionColor = new("_EmissionColor");
-	// Repeating ramp
 	private static MaterialProperty _RampTexture = new("_RampTexture");
 	private static MaterialProperty _Scale = new("_Scale");
 	private static MaterialProperty _ScrollSpeed = new("_ScrollSpeed");
-	// Fresnel
 	private static MaterialProperty _FresnelColor = new("_FresnelColor");
-	private static MaterialProperty _FresnelExponent = new("_FresnelExponent");
+    private static MaterialProperty _FresnelExponent = new("_FresnelExponent");
 
 	public override PropertyState PropertyInitializationState
 	{
@@ -45,16 +39,13 @@ public class Hologram : SingleShaderMaterialProvider
 	}
 	protected override void UpdateMaterial(Material material)
 	{
-		// Main
 		material.UpdateTexture(_MainTexture, MainTexture);
 		material.UpdateColor(_MainColor, MainColor);
 		material.UpdateTexture(_EmissionTexture, EmissionTexture);
 		material.UpdateColor(_EmissionColor, EmissionColor);
-		// Repeating ramp
 		material.UpdateTexture(_RampTexture, RampTexture);
 		material.UpdateFloat(_Scale, Scale);
 		material.UpdateFloat(_ScrollSpeed, ScrollSpeed);
-		// Fresnel
 		material.UpdateColor(_FresnelColor, FresnelColor);
 		material.UpdateFloat(_FresnelExponent, FresnelExponent);
 

--- a/NEOSPlus/Materials/Effects/ParallaxOcclusion.cs
+++ b/NEOSPlus/Materials/Effects/ParallaxOcclusion.cs
@@ -10,27 +10,31 @@ public class ParallaxOcclusion : SingleShaderMaterialProvider
 
     public readonly Sync<color> Color;
     public readonly AssetRef<ITexture2D> MainTex;
-    public readonly AssetRef<ITexture2D> BumpMap;
-    public readonly Sync<float> BumpScale;
+    public readonly AssetRef<ITexture2D> NormalMap;
+    [Range(0f, 1f, "0.00")]
+    public readonly Sync<float> NormalScale;
     public readonly AssetRef<ITexture2D> ParallaxMap;
+    [Range(0f, 1f, "0.00")]
     public readonly Sync<float> Parallax;
+    [Range(0f, 1f, "0.00")]
     public readonly Sync<float> Glossiness;
+    [Range(0f, 1f, "0.00")]
     public readonly Sync<float> Metallic;
+    [Range(2f, 100f, "0")]
     public readonly Sync<float> ParallaxMinSamples;
+    [Range(2f, 100f, "0")]
     public readonly Sync<float> ParallaxMaxSamples;
 
     private static MaterialProperty _Color = new MaterialProperty("_Color");
     private static MaterialProperty _MainTex = new MaterialProperty("_MainTex");
-    private static MaterialProperty _BumpMap = new MaterialProperty("_BumpMap");
-    private static MaterialProperty _BumpScale = new MaterialProperty("_BumpScale");
+    private static MaterialProperty _NormalMap = new MaterialProperty("_BumpMap");
+    private static MaterialProperty _NormalScale = new MaterialProperty("_BumpScale");
     private static MaterialProperty _ParallaxMap = new MaterialProperty("_ParallaxMap");
     private static MaterialProperty _Parallax = new MaterialProperty("_Parallax");
     private static MaterialProperty _Glossiness = new MaterialProperty("_Glossiness");
     private static MaterialProperty _Metallic = new MaterialProperty("_Metallic");
     private static MaterialProperty _ParallaxMinSamples = new MaterialProperty("_ParallaxMinSamples");
     private static MaterialProperty _ParallaxMaxSamples = new MaterialProperty("_ParallaxMaxSamples");
-
-    // Don't change variable names as it gets confusing to assign values
 
     [DefaultValue(-1)]
     public readonly Sync<int> RenderQueue;
@@ -43,11 +47,10 @@ public class ParallaxOcclusion : SingleShaderMaterialProvider
     }
     protected override void UpdateMaterial(Material material)
     {
-        // Main
         material.UpdateColor(_Color, Color);
         material.UpdateTexture(_MainTex, MainTex);
-        material.UpdateTexture(_BumpMap, BumpMap);
-        material.UpdateFloat(_BumpScale, BumpScale);
+        material.UpdateTexture(_NormalMap, NormalMap);
+        material.UpdateFloat(_NormalScale, NormalScale);
         material.UpdateTexture(_ParallaxMap, ParallaxMap);
         material.UpdateFloat(_Parallax, Parallax);
         material.UpdateFloat(_Glossiness, Glossiness);
@@ -65,7 +68,7 @@ public class ParallaxOcclusion : SingleShaderMaterialProvider
     {
         base.OnAttach();
         Color.Value = new color(1);
-        BumpScale.Value = 1;
+        NormalScale.Value = 1;
         Parallax.Value = 0.05f;
         Glossiness.Value = 0.5f;
         Metallic.Value = 0;

--- a/NEOSPlus/Materials/MToon.cs
+++ b/NEOSPlus/Materials/MToon.cs
@@ -10,69 +10,83 @@ namespace NEOSPlus.Materials
     {
         protected override Uri ShaderURL => ShaderInjection.MToon;
 
+        [Range(0f, 1f, "0.00")]
         public readonly Sync<float> Cutoff;
-        [Range(0f, 1f)] private static MaterialProperty _Cutoff = new("_Cutoff");
         public readonly Sync<color> Color;
-        private static MaterialProperty _Color= new("_Color");
         public readonly Sync<color> ShadeColor;
-        private static MaterialProperty _ShadeColor= new("_ShadeColor");
         public readonly AssetRef<ITexture2D> MainTex;
-        private static MaterialProperty _MainTex = new("_MainTex");
         public readonly AssetRef<ITexture2D> ShadeTexture;
-        private static MaterialProperty _ShadeTexture = new("_ShadeTexture");
         public readonly Sync<float> BumpScale;
-        private static MaterialProperty _BumpScale= new("_BumpScale");
         public readonly AssetRef<ITexture2D> BumpMap;
-        private static MaterialProperty _BumpMap = new("_BumpMap");
+        [Range(0f, 1f, "0.00")] 
         public readonly Sync<float> ReceiveShadowRate;
-        [Range(0f, 1f)] private static MaterialProperty _ReceiveShadowRate = new("_ReceiveShadowRate");
         public readonly AssetRef<ITexture2D> ReceiveShadowTexture;
-        private static MaterialProperty _ReceiveShadowTexture = new("_ReceiveShadowTexture");
+        [Range(0f, 1f, "0.00")]
         public readonly Sync<float> ShadingGradeRate;
-        [Range(0f, 1f)] private static MaterialProperty _ShadingGradeRate = new("_ShadingGradeRate");
         public readonly AssetRef<ITexture2D> ShadingGradeTexture;
-        private static MaterialProperty _ShadingGradeTexture = new("_ShadingGradeTexture");
+        [Range(-1f, 1f, "0.00")]
         public readonly Sync<float> ShadeShift;
-        [Range(-1f, 1f)] private static MaterialProperty _ShadeShift = new("_ShadeShift");
+        [Range(0f, 1f, "0.00")]
         public readonly Sync<float> ShadeToony;
-        [Range(0f, 1f)] private static MaterialProperty _ShadeToony = new("_ShadeToony");
+        [Range(0f, 1f, "0.00")]
         public readonly Sync<float> LightColorAttenuation;
-        [Range(0f, 1f)] private static MaterialProperty _LightColorAttenuation = new("_LightColorAttenuation");
+        [Range(0f, 1f, "0.00")]
         public readonly Sync<float> IndirectLightIntensity;
-        [Range(0f, 1f)] private static MaterialProperty _IndirectLightIntensity = new("_IndirectLightIntensity");
         public readonly Sync<color> RimColor;
-        private static MaterialProperty _RimColor= new("_RimColor");
         public readonly AssetRef<ITexture2D> RimTexture;
-        private static MaterialProperty _RimTexture = new("_RimTexture");
+        [Range(0f, 1f, "0.00")]
         public readonly Sync<float> RimLightingMix;
-        [Range(0f, 1f)] private static MaterialProperty _RimLightingMix = new("_RimLightingMix");
+        [Range(0f, 100f, "0.00")]
         public readonly Sync<float> RimFresnelPower;
-        [Range(0f, 100f)] private static MaterialProperty _RimFresnelPower = new("_RimFresnelPower");
+        [Range(0f, 1f, "0.00")]
         public readonly Sync<float> RimLift;
-        [Range(0f, 1f)] private static MaterialProperty _RimLift = new("_RimLift");
         public readonly AssetRef<ITexture2D> SphereAdd;
-        private static MaterialProperty _SphereAdd = new("_SphereAdd");
         public readonly Sync<color> EmissionColor;
-        private static MaterialProperty _EmissionColor = new("_EmissionColor");
         public readonly AssetRef<ITexture2D> EmissionMap;
-        private static MaterialProperty _EmissionMap = new("_EmissionMap");
         public readonly AssetRef<ITexture2D> OutlineWidthTexture;
-        private static MaterialProperty _OutlineWidthTexture = new("_OutlineWidthTexture");
+        [Range(0.01f, 1f, "0.00")]
         public readonly Sync<float> OutlineWidth;
-        [Range(0.01f, 1f)] private static MaterialProperty _OutlineWidth = new("_OutlineWidth");
+        [Range(0f, 10f, "0.00")]
         public readonly Sync<float> OutlineScaledMaxDistance;
-        [Range(0f, 10f)] private static MaterialProperty _OutlineScaledMaxDistance = new("_OutlineScaledMaxDistance");
         public readonly Sync<color> OutlineColor;
-        private static MaterialProperty _OutlineColor= new("_OutlineColor");
+        [Range(0f, 1f, "0.00")]
         public readonly Sync<float> OutlineLightingMix;
-        [Range(0f, 1f)] private static MaterialProperty _OutlineLightingMix = new("_OutlineLightingMix");
         public readonly AssetRef<ITexture2D> UvAnimMaskTexture;
-        private static MaterialProperty _UvAnimMaskTexture = new("_UvAnimMaskTexture");
         public readonly Sync<float> UvAnimScrollX;
-        private static MaterialProperty _UvAnimScrollX= new("_UvAnimScrollX");
         public readonly Sync<float> UvAnimScrollY;
-        private static MaterialProperty _UvAnimScrollY= new("_UvAnimScrollY");
         public readonly Sync<float> UvAnimRotation;
+
+        private static MaterialProperty _Cutoff = new("_Cutoff");
+        private static MaterialProperty _Color= new("_Color");
+        private static MaterialProperty _ShadeColor= new("_ShadeColor");
+        private static MaterialProperty _MainTex = new("_MainTex");
+        private static MaterialProperty _ShadeTexture = new("_ShadeTexture");
+        private static MaterialProperty _BumpScale= new("_BumpScale");
+        private static MaterialProperty _BumpMap = new("_BumpMap");
+        private static MaterialProperty _ReceiveShadowRate = new("_ReceiveShadowRate");
+        private static MaterialProperty _ReceiveShadowTexture = new("_ReceiveShadowTexture");
+        private static MaterialProperty _ShadingGradeRate = new("_ShadingGradeRate");
+        private static MaterialProperty _ShadingGradeTexture = new("_ShadingGradeTexture");
+        private static MaterialProperty _ShadeShift = new("_ShadeShift");
+        private static MaterialProperty _ShadeToony = new("_ShadeToony");
+        private static MaterialProperty _LightColorAttenuation = new("_LightColorAttenuation");
+        private static MaterialProperty _IndirectLightIntensity = new("_IndirectLightIntensity");
+        private static MaterialProperty _RimColor= new("_RimColor");
+        private static MaterialProperty _RimTexture = new("_RimTexture");
+        private static MaterialProperty _RimLightingMix = new("_RimLightingMix");
+        private static MaterialProperty _RimFresnelPower = new("_RimFresnelPower");
+        private static MaterialProperty _RimLift = new("_RimLift");
+        private static MaterialProperty _SphereAdd = new("_SphereAdd");
+        private static MaterialProperty _EmissionColor = new("_EmissionColor");
+        private static MaterialProperty _EmissionMap = new("_EmissionMap");
+        private static MaterialProperty _OutlineWidthTexture = new("_OutlineWidthTexture");
+        private static MaterialProperty _OutlineWidth = new("_OutlineWidth");
+        private static MaterialProperty _OutlineScaledMaxDistance = new("_OutlineScaledMaxDistance");
+        private static MaterialProperty _OutlineColor= new("_OutlineColor");
+        private static MaterialProperty _OutlineLightingMix = new("_OutlineLightingMix");
+        private static MaterialProperty _UvAnimMaskTexture = new("_UvAnimMaskTexture");
+        private static MaterialProperty _UvAnimScrollX= new("_UvAnimScrollX");
+        private static MaterialProperty _UvAnimScrollY= new("_UvAnimScrollY");
         private static MaterialProperty _UvAnimRotation = new("_UvAnimRotation");
 
         public readonly Sync<float> MToonVersion;

--- a/NEOSPlus/Shaders/ShaderInjection.cs
+++ b/NEOSPlus/Shaders/ShaderInjection.cs
@@ -14,15 +14,15 @@ namespace NEOSPlus.Shaders
         public static readonly Uri NeosPlusTest = new("neosdb:///032da78c8a65dd71ca33cd8ed4ad7222682057b59f7afb3bbe582a42fdc0bbc9.neoshader");
         public static readonly Uri HologramV2 = new("neosdb:///55cbadb64068521f187d408bed05542af1365d4c056b2570b4cc0d6105657902.neoshader");
         public static readonly Uri MToon = new("neosdb:///f9db0509b5413ae1449ca912aedb660aac028d29415c74a7767daf4fafa4c764.neoshader");
-        public static readonly Uri ParallaxOcclusion = new("neosdb:///2e5115ddecc06523c91da9111dfb05f4972fa79330af68214f1fd26752c67a53.neoshader");
+        public static readonly Uri ParallaxOcclusion = new("neosdb:///2539719620e32ca7d0cadd510c8ee088500cb76fc9cb46bb03d5aa586303e451.neoshader");
 
         private static readonly List<Uri> Shaders = new()
         {
-            ParallaxOcclusion,
             Hologram_Archived,
             NeosPlusTest,
             HologramV2,
-            MToon
+            MToon,
+            ParallaxOcclusion
         };
 
         private static async Task RegisterShader(Uri uri)
@@ -36,6 +36,7 @@ namespace NEOSPlus.Shaders
         // New note I think xLinka and I both clocked in a min of 13 hours each trying to get it to work but again thankfully we got it working -Panda
         // More hours are being poured into the bloody thing working cause they are hit or miss
         // So it turns out asset servers are realy fiddly to work with
+        // More about the servers, I've had lows of 5 minutes upon uploading to have stuff work then up to multiple days to work :)
 
         public static void AppendShaders() => Task.WaitAll(Shaders.Select(shader => RegisterShader(shader)).ToArray());
     }


### PR DESCRIPTION
Fixed
- ParallaxOcclusion shader not working from issue [#116](https://github.com/Xlinka/NeosPlus/issues/116)
- Material orbs now have sliders instead of integers to reflect what it has in the shader code

Changed
- Moved ParallaxOcclusion to Materials/Effects to reflect its ingame location

Notes
- If possible move .cginc code into shader file because that is what was preventing ParallaxOcclusion from working correctly in Neos