### PR TITLE
replace broken copy to plugin functionality with an actually working one

### DIFF
--- a/NEOSPlus.sln
+++ b/NEOSPlus.sln
@@ -10,23 +10,18 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		AutoPostX|Any CPU = AutoPostX|Any CPU
-		CopyToPlugin|Any CPU = CopyToPlugin|Any CPU
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{08A94620-ECB7-41FD-8C9C-C11F2EBFC776}.AutoPostX|Any CPU.ActiveCfg = AutoPostX|Any CPU
 		{08A94620-ECB7-41FD-8C9C-C11F2EBFC776}.AutoPostX|Any CPU.Build.0 = AutoPostX|Any CPU
-		{08A94620-ECB7-41FD-8C9C-C11F2EBFC776}.CopyToPlugin|Any CPU.ActiveCfg = Debug|Any CPU
-		{08A94620-ECB7-41FD-8C9C-C11F2EBFC776}.CopyToPlugin|Any CPU.Build.0 = Debug|Any CPU
 		{08A94620-ECB7-41FD-8C9C-C11F2EBFC776}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{08A94620-ECB7-41FD-8C9C-C11F2EBFC776}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{08A94620-ECB7-41FD-8C9C-C11F2EBFC776}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{08A94620-ECB7-41FD-8C9C-C11F2EBFC776}.Release|Any CPU.Build.0 = Release|Any CPU
 		{88053493-5CC5-41EA-B598-816373CF48FE}.AutoPostX|Any CPU.ActiveCfg = AutoPostX|Any CPU
 		{88053493-5CC5-41EA-B598-816373CF48FE}.AutoPostX|Any CPU.Build.0 = AutoPostX|Any CPU
-		{88053493-5CC5-41EA-B598-816373CF48FE}.CopyToPlugin|Any CPU.ActiveCfg = CopyToPlugin|Any CPU
-		{88053493-5CC5-41EA-B598-816373CF48FE}.CopyToPlugin|Any CPU.Build.0 = CopyToPlugin|Any CPU
 		{88053493-5CC5-41EA-B598-816373CF48FE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{88053493-5CC5-41EA-B598-816373CF48FE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{88053493-5CC5-41EA-B598-816373CF48FE}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/NEOSPlus/NEOSPlus.csproj
+++ b/NEOSPlus/NEOSPlus.csproj
@@ -7,6 +7,8 @@
     <LangVersion>10</LangVersion>
     <Copyright>Copyright ©  2022</Copyright>
     <Product>NEOSPlus</Product>
+    <!-- SET THIS BOOL TO TRUE TO COPY TO PLUGINS V -->
+    <CopyToPlugins Condition="'$(CopyToPlugins)'==''">false</CopyToPlugins>
   </PropertyGroup>
   <PropertyGroup>
     <NeosPath>$(MSBuildThisFileDirectory)NeosVR\</NeosPath>
@@ -16,9 +18,6 @@
     <NeosPath Condition="Exists('C:\Neos\app\')">C:\Neos\app\</NeosPath>
     <NeosPath Condition="Exists('E:\Neos\app\')">E:\Neos\app\</NeosPath>
     <NeosPath Condition="Exists('E:\SteamLibrary/steamapps/common/NeosVR/')">E:\SteamLibrary/steamapps/common/NeosVR/</NeosPath>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'CopyToPlugin|AnyCPU'">
-    <PostBuildEvent>echo Copying "$(TargetPath)" to "$(NeosPath)\Libraries"</PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'AutoPostX|AnyCPU' ">
     <PostBuildEvent>cd "$(ProjectDir)"
@@ -82,4 +81,8 @@
     <ProjectReference Include="..\SourceGenerators\SourceGenerators.csproj" OutputItemType="Analyzer" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3"> </PackageReference>
   </ItemGroup>
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="'$(CopyToPlugins)'=='true'">
+    <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(NeosPath)Libraries" />
+    <Message Text="Copied $(TargetFileName) to $(NeosPath)Libraries" Importance="high" />
+  </Target>
 </Project>

--- a/NEOSPlus/NEOSPlus.csproj
+++ b/NEOSPlus/NEOSPlus.csproj
@@ -7,7 +7,7 @@
     <LangVersion>10</LangVersion>
     <Copyright>Copyright ©  2022</Copyright>
     <Product>NEOSPlus</Product>
-    <!-- SET THIS BOOL TO TRUE TO COPY TO PLUGINS V -->
+    <!-- SET THIS BOOL TO TRUE TO COPY TO PLUGINS       V -->
     <CopyToPlugins Condition="'$(CopyToPlugins)'==''">false</CopyToPlugins>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
disabled by default, can be enabled by changing `false` to `true` in the `CopyToPlugins` line in the csproj

this solution is also cross platform as opposed to the other one which was not.

this fixes #151